### PR TITLE
Moving Regularization

### DIFF
--- a/combined_mcmc_constraint.py
+++ b/combined_mcmc_constraint.py
@@ -29,7 +29,7 @@ class CombinedMCMCConstraint:
 
         solution = root_scalar(lambda x: cdf_func(x) - cdf_value,
                                bracket=(self._grid[0], self._grid[-1]))
-        assert solution.converged
+        assert solution.converged, repr(solution)
         return solution.root
 
 

--- a/mcmc_quantile_convergence.py
+++ b/mcmc_quantile_convergence.py
@@ -7,7 +7,51 @@ import numpy
 from general_purpose_python_modules.discrete_markov import \
     DiscreteMarkov
 
-def get_approximate_markov(chain, num_states=None):
+def regularize_discrete_chain(input_chain):
+    """
+    Return a chain over only states represented in the input chain.
+
+    Args:
+        input_chain(array):    A chain of integers, possibly non-sequential.
+
+    Returns:
+        array(int):
+            An equivalent chain with all states in the input chain relabeled to
+            form a sequence of consecutive integers starting at 0.
+
+        array(int):
+            The state in the input chain that corresponds to each of the states
+            of the new chain.
+    """
+
+    while input_chain.size > 1 and (input_chain == input_chain[-1]).sum() == 1:
+        input_chain = input_chain[:-1]
+
+    if input_chain.size <= 1:
+        return None, None
+
+    represented_states = numpy.unique(input_chain)
+    assert input_chain.min() >= 0
+    if represented_states.size == input_chain.max() + 1:
+        print("Chain already regular.")
+        return input_chain, represented_states
+
+    print("Regularizing irregular chain.")
+    output_chain = numpy.empty(input_chain.shape, dtype=input_chain.dtype)
+    for new, old in enumerate(represented_states):
+        update = input_chain == old
+        output_chain[update] = new
+
+    return output_chain, represented_states
+
+def get_approximate_markov(
+    chain,
+    num_states=None,
+    preregular=True,
+    samples=None,
+    burnin=None,
+    quantile=None
+):
     """
     Return order 1 Markov process fit to thinned chain and the thinning used.
 
@@ -18,6 +62,18 @@ def get_approximate_markov(chain, num_states=None):
         num_states(int):    The number of states the process samples over  (in
             case not all are represented in `chain`). If None, `chain.max()` is
             used.
+
+        preregular(bool):    If False, the chain will be regularized before each
+            fit. If True, the chain is assumed to already be regularized, and that
+            thinning it will not change the number of states.
+
+        samples(array):    If not preregular, the emcee samples we're approximating.
+
+        burnin(int):    If not preregular, the number of samples to discard from
+            the start of the chain before thinning.
+
+        quantile(float):    If not preregular, the quantile value to use for
+            regularization.
 
     Returns:
         float, float:
@@ -31,31 +87,45 @@ def get_approximate_markov(chain, num_states=None):
 
 
     fitted_markov = DiscreteMarkov(samples_size=0)
-    if num_states is None:
-        num_states = chain.max() + 1
 
     thinning_statistic = 1
     thin = 0
+    num_below_states = None
     while thinning_statistic > 0:
         thin += 1
         if thin >  0.1 * chain.size:
             print('Thin %d too big. Giving up. Chain:' % thin)
             print(repr(chain))
-            return None, 0
+            return None, 0, None, None
+        
+        if not preregular:
+            #if burnin < samples.shape[0] - 1:
+            regular_indicator_chain, num_below_states = regularize_discrete_chain(
+                (samples[burnin::thin] < quantile).astype(int).sum(axis=1)
+            )
+            chain = regular_indicator_chain
+            if chain is None:
+                print('Chain regularization failed. Returning None.')
+                return None, 0, None, None
+            num_states = chain.max() + 1
+        
+        if num_states is None:
+            num_states = chain.max() + 1
+
         thinning_statistic = (
-            DiscreteMarkov(samples_size=0).fit(chain[::thin],
+            DiscreteMarkov(samples_size=0).fit(chain,
                                                num_states,
                                                2,
                                                True)
             -
-            fitted_markov.fit(chain[::thin], num_states, 1, True)
+            fitted_markov.fit(chain, num_states, 1, True)
             -
             num_states * (num_states - 1)**2 / 2.0
             *
-            numpy.log(chain[::thin].size)
+            numpy.log(chain.size)
         )
 
-    return fitted_markov, thin
+    return fitted_markov, thin, num_below_states, chain
 
 
 def get_approximate_binary_markov(binary_chain):

--- a/mcmc_quantile_convergence.py
+++ b/mcmc_quantile_convergence.py
@@ -47,9 +47,7 @@ def regularize_discrete_chain(input_chain):
 def get_approximate_markov(
     chain,
     num_states=None,
-    preregular=True,
-    samples=None,
-    burnin=None,
+    regularize=False,
     quantile=None
 ):
     """
@@ -57,27 +55,22 @@ def get_approximate_markov(
 
     Args:
         chain(array):    A chain of discrete values that will be thinned until
-            it is well approximated by an order 1 Markov process.
+            it is well-approximated by an order 1 Markov process.
 
         num_states(int):    The number of states the process samples over  (in
             case not all are represented in `chain`). If None, `chain.max()` is
             used.
 
-        preregular(bool):    If False, the chain will be regularized before each
-            fit. If True, the chain is assumed to already be regularized, and that
+        regularize(bool):    If True, the chain will be regularized before each
+            fit. If False, the chain is assumed to already be regularized, and that
             thinning it will not change the number of states.
 
-        samples(array):    If not preregular, the emcee samples we're approximating.
-
-        burnin(int):    If not preregular, the number of samples to discard from
-            the start of the chain before thinning.
-
-        quantile(float):    If not preregular, the quantile value to use for
+        quantile(float):    If regularize, the quantile value to use for
             regularization.
 
     Returns:
         float, float:
-            The maximum likelihood estimet of the transition probabilities 0->1
+            The maximum likelihood estimate of the transition probabilities 0->1
             and 1->0 respectively.
 
         int:
@@ -87,6 +80,8 @@ def get_approximate_markov(
 
 
     fitted_markov = DiscreteMarkov(samples_size=0)
+    if regularize:
+        samples = chain
 
     thinning_statistic = 1
     thin = 0
@@ -98,10 +93,10 @@ def get_approximate_markov(
             print(repr(chain))
             return None, 0, None, None
         
-        if not preregular:
+        if regularize:
             #if burnin < samples.shape[0] - 1:
             regular_indicator_chain, num_below_states = regularize_discrete_chain(
-                (samples[burnin::thin] < quantile).astype(int).sum(axis=1)
+                (samples[::thin] < quantile).astype(int).sum(axis=1)
             )
             chain = regular_indicator_chain
             if chain is None:


### PR DESCRIPTION
This PR moves regularization to after thinning when finding quantile convergence. Doing so solves an issue where thinning removes one of the states entirely, leading to issues counting states later.

The `regularize_discrete_chain()` function was moved from `emcee_quantile_convergence.py` to `mcmc_quantile_convergence.py`, to avoid circular references when importing. In that same function, a typo was fixed.

An instance of `regularize_discrete_chain()` can probably be removed from `find_emcee_quantiles()`, allowing for a reduction in the number of arguments that need to be passed to `diagnose_emcee_quantile()`. However, I wanted to hold off on that for now to avoid needing to propagate that change to `get_emcee_quantile_diagnostics()', which might be getting deleted soon anyway.